### PR TITLE
bug-fix/easing restrictions on foreign keys

### DIFF
--- a/data/migrations/20201215173942_alter-profiles.js
+++ b/data/migrations/20201215173942_alter-profiles.js
@@ -1,25 +1,13 @@
 exports.up = (knex) => {
   return knex.schema.table('profiles', function (table) {
     table.integer('role').unsigned();
-    table
-      .foreign('role')
-      .references('roles.id')
-      .onDelete('CASCADE')
-      .onUpdate('CASCADE');
     table.integer('company').unsigned();
-    table
-      .foreign('company')
-      .references('companies.id')
-      .onDelete('CASCADE')
-      .onUpdate('CASCADE');
   });
 };
 
 exports.down = (knex) => {
   return knex.schema.table('profiles', function (table) {
-    table.dropForeign('company');
     table.dropColumn('company');
-    table.dropForeign('role');
     table.dropColumn('role');
   });
 };

--- a/data/migrations/20201215174422_create-workOrders.js
+++ b/data/migrations/20201215174422_create-workOrders.js
@@ -10,11 +10,6 @@ exports.up = (knex) => {
       .onDelete('CASCADE')
       .onUpdate('CASCADE');
     table.integer('property').unsigned();
-    table
-      .foreign('property')
-      .references('properties.id')
-      .onDelete('CASCADE')
-      .onUpdate('CASCADE');
     table.string('createdBy');
     table
       .foreign('createdBy')
@@ -22,11 +17,6 @@ exports.up = (knex) => {
       .onDelete('CASCADE')
       .onUpdate('CASCADE');
     table.string('assignedTo');
-    table
-      .foreign('assignedTo')
-      .references('profiles.id')
-      .onDelete('CASCADE')
-      .onUpdate('CASCADE');
     table.integer('priority').unsigned();
     table
       .foreign('priority')

--- a/data/migrations/20210106214521_fix-foreign-keys.js
+++ b/data/migrations/20210106214521_fix-foreign-keys.js
@@ -8,14 +8,6 @@ exports.up = function (knex) {
         .onDelete('CASCADE')
         .onUpdate('CASCADE');
     })
-    .table('profiles', function (table) {
-      table.dropForeign('company');
-      table
-        .foreign('company')
-        .references('companies.id')
-        .onDelete('CASCADE')
-        .onUpdate('CASCADE');
-    })
     .table('properties', function (table) {
       table.dropForeign('company');
       table
@@ -31,21 +23,9 @@ exports.up = function (knex) {
         .references('companies.id')
         .onDelete('CASCADE')
         .onUpdate('CASCADE');
-      table.dropForeign('property');
-      table
-        .foreign('property')
-        .references('properties.id')
-        .onDelete('CASCADE')
-        .onUpdate('CASCADE');
       table.dropForeign('createdBy');
       table
         .foreign('createdBy')
-        .references('profiles.id')
-        .onDelete('CASCADE')
-        .onUpdate('CASCADE');
-      table.dropForeign('assignedTo');
-      table
-        .foreign('assignedTo')
         .references('profiles.id')
         .onDelete('CASCADE')
         .onUpdate('CASCADE');

--- a/data/seeds/001_profiles.js
+++ b/data/seeds/001_profiles.js
@@ -8,6 +8,8 @@ const profiles = [...new Array(5)].map((i, idx) => ({
     idx === 0
       ? 'Test001 User'
       : `${faker.name.firstName()} ${faker.name.lastName()}`,
+  role: idx === 0 ? 1 : Math.min(idx + 2, 6),
+  company: 1,
 }));
 
 exports.seed = function (knex) {


### PR DESCRIPTION
Jose and I noticed that some of the foreign key references were too restrictive and made inserting new objects difficult. This fix removes the foreign key restriction on some of the references. They still reference the other object, but are not all required.

No longer restricted:
- Profiles.company
- Profiles.role
- WorkOrders.property
- WorkOrders.assignedTo

Still restricted:
- Roles.company
- Properties.company
- WorkOrders.company
- WorkOrders.createdBy
- WorkOrders.status
- WorkOrders.priority
- Comments.author
- Comments.workOrder
- Images.user
- Images.workOrder

Also adjusted the DB seeds to reflect the change.
Unfortunately, I couldn't figure out how to do this without requiring a full `migrate:rollback` to base, `migrate:latest`, and `seed:run`