### PR TITLE
router and models updated for comments and images

### DIFF
--- a/api/workOrder/workOrderModel.js
+++ b/api/workOrder/workOrderModel.js
@@ -163,6 +163,48 @@ const remove = async (id) => {
   return await db('workOrders').where({ id }).del();
 };
 
+const getComments = (workOrderId) => {
+  return db('comments')
+    .from('comments as c')
+    .where({ workOrder: workOrderId })
+    .join('profiles as u', 'c.author', 'u.id')
+    .select('c.id', 'c.comment', 'c.workOrder', 'u.id', 'u.name')
+    .distinctOn('c.id');
+};
+
+const addComment = (comment) => {
+  return db('comments').insert(comment).returning('*');
+};
+
+const updateComment = (id, comment) => {
+  return db('comments')
+    .where({ id: id })
+    .first()
+    .update(comment)
+    .returning('*');
+};
+
+const removeComment = async (id) => {
+  return await db('comments').where({ id }).del();
+};
+
+const getImages = (workOrderId) => {
+  return db('images')
+    .from('images as i')
+    .where({ workOrder: workOrderId })
+    .join('profiles as u', 'i.user', 'u.id')
+    .select('i.id', 'i.url', 'i.workOrder', 'u.id', 'u.name')
+    .distinctOn('i.id');
+};
+
+const addImage = (image) => {
+  return db('images').insert(image).returning('*');
+};
+
+const removeImage = async (id) => {
+  return await db('images').where({ id }).del();
+};
+
 module.exports = {
   findAll,
   findByUser,
@@ -172,4 +214,11 @@ module.exports = {
   create,
   update,
   remove,
+  getComments,
+  addComment,
+  updateComment,
+  removeComment,
+  getImages,
+  addImage,
+  removeImage,
 };

--- a/api/workOrder/workOrderRouter.js
+++ b/api/workOrder/workOrderRouter.js
@@ -498,4 +498,101 @@ router.delete('/:id', authRequired, function (req, res) {
   }
 });
 
+router.get('/:id/comments?', authRequired, function (req, res) {
+  const workOrderId = req.params.id;
+  WorkOrders.getComments(workOrderId)
+    .then((comments) => {
+      res.status(200).json(comments);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: err.message });
+    });
+});
+
+router.post('/:id/comments?', authRequired, function (req, res) {
+  const comment = req.body;
+  try {
+    WorkOrders.addComment(comment).then((comment) =>
+      res.status(200).json({ message: 'comment added', comment: comment[0] })
+    );
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ message: e.message });
+  }
+});
+
+router.put('/:id/comments?/:commentId', authRequired, function (req, res) {
+  const commentId = req.params.commentId;
+  const comment = req.body;
+  try {
+    WorkOrders.updateComment(commentId, comment).then((updated) => {
+      res.status(200).json({ message: 'comment updated', comment: updated[0] });
+    });
+  } catch (err) {
+    res.status(500).json({
+      message: `Could not update comment '${commentId}'`,
+      error: err.message,
+    });
+  }
+});
+
+router.delete('/:id/comments?/:commentId', authRequired, function (req, res) {
+  const id = req.params.commentId;
+  try {
+    WorkOrders.removeComment(id).then((comment) => {
+      res.status(200).json({
+        message: `comment '${id}' was deleted.`,
+        comment: comment,
+      });
+    });
+  } catch (err) {
+    res.status(500).json({
+      message: `Could not delete comment with ID: ${id}`,
+      error: err.message,
+    });
+  }
+});
+
+router.get('/:id/images?', authRequired, function (req, res) {
+  const workOrderId = req.params.id;
+  WorkOrders.getImages(workOrderId)
+    .then((images) => {
+      res.status(200).json(images);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: err.message });
+    });
+});
+
+router.post('/:id/images?', authRequired, function (req, res) {
+  const image = req.body;
+  try {
+    WorkOrders.addImage(image).then((image) =>
+      res.status(200).json({ message: 'image added', comment: image[0] })
+    );
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ message: e.message });
+  }
+});
+
+router.delete('/:id/images?/:imageId', authRequired, function (req, res) {
+  const id = req.params.imageId;
+  try {
+    WorkOrders.removeImage(id).then((image) => {
+      res.status(200).json({
+        message: `image '${id}' was deleted.`,
+        image: image,
+      });
+    });
+  } catch (err) {
+    res.status(500).json({
+      message: `Could not delete image with ID: ${id}`,
+      error: err.message,
+    });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
We had previously not had a way to add comments and images to a work order.
This branch adds the following endpoints:

`GET /{workOrderId}/comments` => gets all comments associated with a WO
`POST /{workOrderId}/comments` => add a comment
`PUT /{workOrderId}/comment/{commentId}` => update a comment
`DELETE /{workOrderId}/comment/{commentId}` => remove a comment

`GET /{workOrderId}/images` => gets all images associated with a WO
`POST /{workOrderId}/images` => add an image
`DELETE /{workOrderId}/image/{imageId}` => remove an image