### PR TITLE
Added endpoints for the creation of new users with new system

### DIFF
--- a/api/userCrud/userModel.js
+++ b/api/userCrud/userModel.js
@@ -1,5 +1,5 @@
 const db = require('../../data/db-config');
-const Roles = require('../company/companyModel');
+const Companies = require('../company/companyModel');
 
 const getCompany = async (id) => {
   return await db('companies').select().where('id', '=', id);
@@ -17,14 +17,23 @@ const createUser = async (user) => {
 };
 
 const createUserWithCode = async (user, code) => {
-  const role = await Roles.findRoleByCode(code);
+  const role = await Companies.findRoleByCode(code);
   if (role) {
     user.role = role.id;
     user.company = role.company;
-    createUser(user);
+    return createUser(user);
   } else {
     return undefined;
   }
+};
+
+const createUserNewCompany = async (user, company) => {
+  const createdCompany = await Companies.create(company);
+  user.company = createdCompany.id;
+  const roles = await Companies.findCompanyRoles(createdCompany.id);
+  const role = roles.find((r) => r.name === 'Admin');
+  user.role = role.id;
+  return createUser(user);
 };
 
 const updateProfile = async (updates, userId) => {
@@ -41,6 +50,7 @@ module.exports = {
   getCompanyUser,
   createUser,
   createUserWithCode,
+  createUserNewCompany,
   updateProfile,
   deleteUser,
 };

--- a/api/userCrud/userModel.js
+++ b/api/userCrud/userModel.js
@@ -1,4 +1,5 @@
 const db = require('../../data/db-config');
+const Roles = require('../company/companyModel');
 
 const getCompany = async (id) => {
   return await db('companies').select().where('id', '=', id);
@@ -15,6 +16,17 @@ const createUser = async (user) => {
   return await db('profiles').insert(user);
 };
 
+const createUserWithCode = async (user, code) => {
+  const role = await Roles.findRoleByCode(code);
+  if (role) {
+    user.role = role.id;
+    user.company = role.company;
+    createUser(user);
+  } else {
+    return undefined;
+  }
+};
+
 const updateProfile = async (updates, userId) => {
   return await db('profiles').where('id', '=', userId).update(updates);
 };
@@ -28,6 +40,7 @@ module.exports = {
   getCompanyUsers,
   getCompanyUser,
   createUser,
+  createUserWithCode,
   updateProfile,
   deleteUser,
 };

--- a/api/userCrud/userModel.js
+++ b/api/userCrud/userModel.js
@@ -36,6 +36,15 @@ const createUserNewCompany = async (user, company) => {
   return createUser(user);
 };
 
+const assignUser = async (userId, code) => {
+  const role = await Companies.findRoleByCode(code);
+  if (role) {
+    return updateProfile({ role: role.id, company: role.company }, userId);
+  } else {
+    return undefined;
+  }
+};
+
 const updateProfile = async (updates, userId) => {
   return await db('profiles').where('id', '=', userId).update(updates);
 };
@@ -51,6 +60,7 @@ module.exports = {
   createUser,
   createUserWithCode,
   createUserNewCompany,
+  assignUser,
   updateProfile,
   deleteUser,
 };

--- a/api/userCrud/userRouter.js
+++ b/api/userCrud/userRouter.js
@@ -191,9 +191,8 @@ router.post('/:company_id/user', companyIdCheck, function (req, res) {
  *        $ref: '#/components/responses/NotFound'
  */
 router.post('/user/:code', function (req, res) {
-  const createUser = req.body;
   userModel
-    .createUserWithCode(createUser, req.params.code)
+    .createUserWithCode(req.body, req.params.code)
     .then((user) => {
       res.status(200).json(user);
     })
@@ -283,6 +282,18 @@ router.put('/user/:user_id', userIdCheck, function (req, res) {
     .updateProfile(updates, req.params.user_id)
     .then((user) => {
       res.status(200).json({ message: req.body, user });
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: 'Unable to update', err });
+    });
+});
+
+router.put('/user/:user_id/:code', userIdCheck, function (req, res) {
+  userModel
+    .assignUser(req.params.user_id, req.params.code)
+    .then((user) => {
+      res.status(200).json({ message: 'User added.', user });
     })
     .catch((err) => {
       console.log(err);

--- a/api/userCrud/userRouter.js
+++ b/api/userCrud/userRouter.js
@@ -163,6 +163,48 @@ router.post('/:company_id/user', companyIdCheck, function (req, res) {
 
 /**
  * @swagger
+ * /company/user/{code}:
+ *  post:
+ *    description: add a user
+ *    summary: add a user
+ *    security:
+ *      - okta: []
+ *    tags:
+ *      - users
+ *    requestBody:
+ *      description: user object to to be added (minus id, foreign keys represented by integers or uuid)
+ *      content:
+ *        application/json:
+ *          schema:
+ *            $ref: '#/components/schemas/user'
+ *    responses:
+ *      200:
+ *        description: the new user object
+ *        content:
+ *          application/json:
+ *             $ref: '#/components/schemas/user'
+ *      401:
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      403:
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      500:
+ *        $ref: '#/components/responses/NotFound'
+ */
+router.post('/user/:code', function (req, res) {
+  const createUser = req.body;
+  userModel
+    .createUserWithCode(createUser, req.params.code)
+    .then((user) => {
+      res.status(200).json(user);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: 'Something went wrong', err });
+    });
+});
+
+/**
+ * @swagger
  * /company/user/{userId}:
  *  post:
  *    description: update a user

--- a/api/userCrud/userRouter.js
+++ b/api/userCrud/userRouter.js
@@ -205,6 +205,50 @@ router.post('/user/:code', function (req, res) {
 
 /**
  * @swagger
+ * /company/new:
+ *  post:
+ *    description: create a company and add a user
+ *    summary: create a company and add a user
+ *    security:
+ *      - okta: []
+ *    tags:
+ *      - users
+ *      - company
+ *    requestBody:
+ *      description: user object to to be added (minus id, foreign keys represented by integers or uuid)
+ *      content:
+ *        application/json:
+ *          schema:
+ *            $ref: '#/components/schemas/user'
+ *    responses:
+ *      200:
+ *        description: the new user object
+ *        content:
+ *          application/json:
+ *             $ref: '#/components/schemas/user'
+ *      401:
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      403:
+ *        $ref: '#/components/responses/UnauthorizedError'
+ *      500:
+ *        $ref: '#/components/responses/NotFound'
+ */
+router.post('/new', function (req, res) {
+  const createUser = req.body.user;
+  const createCompany = req.body.company;
+  userModel
+    .createUserNewCompany(createUser, createCompany)
+    .then((user) => {
+      res.status(200).json(user);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: 'Something went wrong', err });
+    });
+});
+
+/**
+ * @swagger
  * /company/user/{userId}:
  *  post:
  *    description: update a user


### PR DESCRIPTION
`/company/user/{code}` - creates a new user, putting them into the company and role specified by the code
`/company/new` - expects `req.body` to contain both a user object and a company object. Creates the company, creates the user, adding the user as the 'Admin' of the new company. (I didn't know what path to put this on, so it can be changed if the team thinks of a better endpoint. Aside: we should review all the endpoints after the functionality is finalized and make sure they are useful labels.)
`/company/user/{userId}/{code}` - adds the user with the specified userId to the company and role associated with the code.

Dependent upon the `feature/registration-codes` branch.